### PR TITLE
Long title handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 		<title>Webian Shell</title>
 		<link rel="stylesheet" href="main.css" type="text/css" />
 		<script type="text/javascript" src="jquery.js"></script>
+		<script type="text/javascript" src="jquery.mousewheel.js"></script>
 		<script type="text/javascript" src="main.js"></script>
 	</head>
 
@@ -56,7 +57,13 @@
 					<input type="image" src="back.png" class="back_button button" alt="Back">
 					<input type="image" src="forward.png" class="forward_button button" alt="Forward">
 					<div class="address_bar">
-						<span class="document_title"></span>
+						<div class="document_title_holder">
+							<div class="inner_title_holder">
+								<div>
+									<span class="document_title"></span>
+								</div>
+							</div>
+						</div>
 						<form class="url_form">
 							<input type="text" class="url_input">
 						</form>

--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -1,0 +1,85 @@
+/**
+ * 
+ * credits for this plugin go to brandonaaron.net
+ * 	
+ * unfortunately his site is down
+ * 
+ * @param {Object} up
+ * @param {Object} down
+ * @param {Object} preventDefault
+ */
+jQuery.fn.extend({
+	mousewheel: function(up, down, preventDefault) {
+		return this.hover(
+			function() {
+				jQuery.event.mousewheel.giveFocus(this, up, down, preventDefault);
+			},
+			function() {
+				jQuery.event.mousewheel.removeFocus(this);
+			}
+		);
+	},
+	mousewheeldown: function(fn, preventDefault) {
+		return this.mousewheel(function(){}, fn, preventDefault);
+	},
+	mousewheelup: function(fn, preventDefault) {
+		return this.mousewheel(fn, function(){}, preventDefault);
+	},
+	unmousewheel: function() {
+		return this.each(function() {
+			// Try to remove mouseover and mouseout events
+			try{
+				jQuery(this).unmouseover().unmouseout();
+			} catch(e) {
+				// unmouseover and unmouseout != exist.
+				// @todo: figure out what these functions are supposed to do and where they're supposed to come from.
+			}
+			jQuery.event.mousewheel.removeFocus(this);
+		});
+	},
+	unmousewheeldown: jQuery.fn.unmousewheel,
+	unmousewheelup: jQuery.fn.unmousewheel
+});
+
+
+jQuery.event.mousewheel = {
+	giveFocus: function(el, up, down, preventDefault) {
+		if (el._handleMousewheel) jQuery(el).unmousewheel();
+		
+		if (preventDefault == window.undefined && down && down.constructor != Function) {
+			preventDefault = down;
+			down = null;
+		}
+		
+		el._handleMousewheel = function(event) {
+			if (!event) event = window.event;
+			if (preventDefault)
+				if (event.preventDefault) event.preventDefault();
+				else event.returnValue = false;
+			var delta = 0;
+			if (event.wheelDelta) {
+				delta = event.wheelDelta/120;
+				if (window.opera) delta = -delta;
+			} else if (event.detail) {
+				delta = -event.detail/3;
+			}
+			if (up && (delta > 0 || !down))
+				up.apply(el, [event, delta]);
+			else if (down && delta < 0)
+				down.apply(el, [event, delta]);
+		};
+		
+		if (window.addEventListener)
+			window.addEventListener('DOMMouseScroll', el._handleMousewheel, false);
+		window.onmousewheel = document.onmousewheel = el._handleMousewheel;
+	},
+	
+	removeFocus: function(el) {
+		if (!el._handleMousewheel) return;
+		
+		if (window.removeEventListener)
+			window.removeEventListener('DOMMouseScroll', el._handleMousewheel, false);
+		window.onmousewheel = document.onmousewheel = null;
+		el._handleMousewheel = null;
+	}
+};

--- a/main.css
+++ b/main.css
@@ -147,27 +147,41 @@ body {
 	border-top-right-radius: 5px;
 	border-top-left-radius: 5px;
 }
-
 .button {
 	width: 20px;
 	height: 20px;
 	padding: 5px 4px;
 }
-
-.document_title {
+.document_title_holder,
+.document_title_holder div,
+.document_title_holder span {
+	display: inline-block;
 	float: left;
+}
+.inner_title_holder > div {
+	overflow: hidden;
+}
+
+.document_title_holder {
+	white-space: nowrap;
+	overflow-x: hidden;
+}
+.title_controller, .document_title {
+	float: left;
+	white-space: nowrap;
 	color: #fff;
 	font-weight: bold;
 	padding: 2px 5px;
 	display: none;
 	visibility: hidden;
 }
-
-.document_title.active {
-	display: block;
+.title_controller.active, .document_title.active {
+	display: inline-block;
 	visibility: visible;
 }
-
+.title_controller.active:hover, .title_controller.active:focus {
+	cursor: pointer;
+}
 .address_bar {
 	-moz-box-flex: 1;
 	display: -moz-box;


### PR DESCRIPTION
I worked out a prototype of how to handle long titles.
## What it currently does

Basically: when the title is over 30 characters, it is trimmed down to 30 characters and an ellipsis (html entity for '...') is shown. When this ellipsis is clicked, the title expands but the wrapper only allows 50% of the status bar length. 
Meaning that in super-overly-long titles, the title is only shown for as much is allowed (as in max-width = 50%). But when scrolling up on this title you can go through the title. Scrolling down will then do the reverse.
The ellipsis is then changed to '{}'. When this is clicked, we go back to the trimmed title with expanding when clicked on '...'.
## What it's missing

The overlays I mentioned on http://clinked.com/webian/discussions/title_expansion_behaviour for the beginning and ending of the title. This should be added in the near-future, because the behaviour isn't completely obvious without it.
## Destination

I would prefer to put this in an experimental branch, which you suggested before. The issue that this fixes isn't on a version to-do list yet so it would make to follow this way of working.
